### PR TITLE
Fetch data on reload for miner summary

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -56,7 +56,7 @@ class App extends Component {
         </section>
         <Switch>
           <Route exact path="/" render={() => <MinerSearch findMiner={this.findMiner}/> } />
-          <Route  path="/:id" render={({match}) => <MinerSummary match={match} updateRewards={this.updateRewards} minerRewards={this.state.minerRewards} minerSummary={this.state.minerSummary}/> } />
+          <Route  path="/:id" render={({match}) => <MinerSummary findMiner={this.findMiner} match={match} updateRewards={this.updateRewards} minerRewards={this.state.minerRewards} minerSummary={this.state.minerSummary}/> } />
         </Switch>
         </header>
       </div>

--- a/src/Components/MinerSummary.js
+++ b/src/Components/MinerSummary.js
@@ -4,7 +4,7 @@ import { VictoryChart } from "victory";
 import { VictoryBar } from "victory";
 import { VictoryScatter } from "victory";
 
-const MinerSummary = ({minerSummary, minerRewards, match, updateRewards}) =>{
+const MinerSummary = ({minerSummary, minerRewards, match, updateRewards, findMiner}) =>{
 
   if(!Array.isArray(minerSummary)){
     const name = minerSummary.name.split("-").join(" ")
@@ -27,8 +27,11 @@ const MinerSummary = ({minerSummary, minerRewards, match, updateRewards}) =>{
         </section>
       </section>
     )
+  } else{
+    const minerName = match.url.split(" ").join("-").slice(1)
+    findMiner(minerName)
+    console.log(minerName)
   }
-
 }
 
 export default MinerSummary;


### PR DESCRIPTION
# <p align="center">Miner Finder PR</p>
<hr>

## What will this PR do?
<hr>

- When a user loads to a page that should include a miner summary there is a fetch that is conducted that normally occurs on miner search. 


## Where should the reviewer start?
<hr>

- minerSummary.js


## How should this be manually tested?
<hr>

-


## Any background context you want to provide?
<hr>

-


## What are the relevant tickets?
<hr>

- closes #13 


## Screenshots (if appropriate)
<hr>

-



## Pull request checklist:
<hr>

| Publisher: | Reviewer: |
| ---------- | --------- |
|<ul><li>- [x] I tested this locally for bugs and errors before pushing.</li><li>- [x] This code breaks no existing tests.</li><li>- [x] I have conducted a refactor on the code to remove comments and consoles.</li><li>- [ ] I have requested someone to review my PR.</li></ul> | <ul><li>[ ] I have run test files to confirm this does not fail any existing tests.</li><li>[ ] I have reviewed all files edited</li><li>- [ ] I have asked for clarifying information when I am unclear</li><li>- [ ] This follows best practices and team decided norms.</li></ul>| 


## Questions:
<hr>

-



